### PR TITLE
Pass file_name into file_action method

### DIFF
--- a/class5/2_build_a_shuffled_playlist_extended.rb
+++ b/class5/2_build_a_shuffled_playlist_extended.rb
@@ -86,7 +86,7 @@ puts "WARNING: #{file_name} already exists" if file_exists == true
 puts "(c)ancel, (o)verwrite, or (a)ppend" if file_exists == true
 
 
-def file_action
+def file_action(file_name)
   action = STDIN.gets.chomp ## Okay, not totally sure why STDIN.gets  works but I discovered this fix
   if action == "c"
     puts "Canceled"
@@ -102,5 +102,4 @@ def file_action
   end
 end
 
-file_action
-
+file_action(file_name)


### PR DESCRIPTION
`file_name` is a local variable that exists outside of the `file_action` method. In order to use it, it must be passed into the method.
